### PR TITLE
fix(turbo): fix turbo.json dev pipeline

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,7 @@
     "clean": {},
     "tsc": {},
     "dev": {
+      "dependsOn": ["build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## What does this PR do / why we need it

With a fresh installation of the project (`pnpm i`), if the user tries to start the website locally (`pnpm dev --filter=website`), it will fail since the website is not built. This PR ensures that the website is built before the `pnpm run dev` is ran.

## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
