### PR TITLE
chore: update renovate bot config to use kind/dependency label

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
-  "extends": ["config:js-app", ":gitSignOff", ":rebaseStalePrs", "group:linters", "group:test"],
+  "extends": [
+    "config:js-app",
+    ":gitSignOff",
+    ":rebaseStalePrs",
+    "group:allNonMajor",
+    "group:linters",
+    "group:test"
+  ],
   "labels": ["kind/dependency"],
   "npm": {
     "minimumReleaseAge": "1 day"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:js-app", ":gitSignOff", ":rebaseStalePrs", "group:linters", "group:test"],
-  "labels": ["kind/dependency upgrade"],
+  "labels": ["kind/dependency"],
   "npm": {
     "minimumReleaseAge": "1 day"
   }


### PR DESCRIPTION
## What does this PR do / why we need it
Update the renovate bot to use the `kind/dependency` label since the `kind/dependency upgrade` label has been renamed to `kind/dependency`

## Which issue(s) does this PR fix

Fixes #?

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
