### PR TITLE
chore: add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: If something isn't working
+labels: ['kind/bug', 'status/triage']
+---
+
+### Describe the Bug?
+
+Provide a clear and concise description of the bug.
+
+### What are the steps to reproduce this issue?
+
+1. …
+2. …
+3. …
+
+### Expected Behavior
+
+What do you think should have happened?
+
+### Actual Behavior
+
+What actually happened? Please provide screenshots if applicable.
+
+### Additional information
+
+- Which devices are affected? ie Desktop, Table, Phone
+- Which browsers are affected? ie Chrome, Firefox, Safari, Edge
+- Which version are you using? (We only support the last 2 major versions.)

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,7 @@
+---
+name: Chore
+about: Internal things, technical debt, and to-do tasks to be performed.
+labels: ['kind/chore', 'status/triage']
+---
+
+### What needs to be done?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Janus IDP Community Slack
+    url: https://janus-idp.slack.com/archives/C04EDTPJRK5
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/dependency_upgrade.md
+++ b/.github/ISSUE_TEMPLATE/dependency_upgrade.md
@@ -1,0 +1,23 @@
+---
+name: Dependency Upgrade
+about: Upgrade a dependency in the project
+labels: ['kind/dependency', 'status/triage']
+---
+
+### Which dependency needs to be upgraded?
+
+### What is the current version of the dependency?
+
+### Which version to upgrade to?
+
+### Changelog link
+
+Put the dependency changelog link, if there is one available
+
+### :warning: Is this a breaking change?
+
+_Put an `x` in the boxes that apply_
+
+- [ ] Yes
+- [ ] No
+- [ ] Don't know

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,13 @@
+---
+name: Discussion
+about: Some features/topics need to be discussed before we can work on it.
+labels: ['kind/discussion', 'status/triage']
+---
+
+### What do you want to discuss?
+
+### What does it improve / What problem does it solve?
+
+### What is the recommended proposal?
+
+### What are the alternate solutions?

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation
+about: Improve an existing feature or workflow
+labels: ['kind/documentation', 'status/triage']
+---
+
+### What do you want to improve?
+
+### What is the current documentation?
+
+### What is the new documentation?

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,19 @@
+---
+name: Enhancement
+about: Improve an existing feature or workflow
+labels: ['kind/enhancement', 'status/triage']
+---
+
+### What do you want to improve?
+
+### What is the current behavior?
+
+### What is the new behavior?
+
+### :warning: Is this a breaking change?
+
+_Put an `x` in the boxes that apply_
+
+- [ ] Yes
+- [ ] No
+- [ ] Don't know

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,27 @@
+---
+name: Epic
+about: A long-lived, PM-driven feature request. Must include a checklist of items that must be completed
+labels: ['kind/epic', 'status/triage']
+---
+
+## Goal
+
+## Acceptance criteria
+
+- [ ] tdb
+
+## Requirements
+
+- [ ] Plugin
+- [ ] Test plan
+- [ ] Installation documentation
+- [ ] End user documentation
+
+## Issues in Epic
+
+- [ ] tbd
+
+## Notes
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: ['kind/feature', 'status/triage']
+---
+
+### Acceptance criteria
+
+What are you trying to do, need? What are the acceptance criteria?
+
+### Who will have access:
+
+_Put an `x` in the boxes that apply_
+
+- [ ] Authenticated user
+- [ ] Unauthenticated user/Guest
+- [ ] System Admin only
+
+### UI/UX
+
+Figma links if needed
+
+### Api documentation/information
+
+OpenAPI link if needed

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,11 @@
+---
+name: Security
+about: Report a security vulnerability/incident
+labels: ['kind/security', 'status/triage', 'priority/critical']
+---
+
+### What is the issue?
+
+### Is there a CVE Mitre link?
+
+### What is the mitigation if known?


### PR DESCRIPTION
## What does this PR do / why we need it
Add default github issue templates that match the organization defaults.

## Which issue(s) does this PR fix

Fixes #179

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
