### PR TITLE
chore(workflow): add add-to-project workflow

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,0 +1,12 @@
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    # https://github.com/janus-idp/.github/blob/main/.github/workflows/add-to-project.yaml
+    uses: janus-idp/.github/.github/workflows/add-to-project.yaml@main
+    with:
+      project_id: 2
+    secrets: inherit


### PR DESCRIPTION
## What does this PR do / why we need it

Adds a github workflow that uses the reusable add-to-project workflow to automatically add newly opened issues in the janus-idp.github.io repository into the github project.

## Which issue(s) does this PR fix

Fixes #241

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
