### PR TITLE
chore(meta): fix lint staged issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,15 @@
   },
   "lint-staged": {
     "*": "turbo run prettier:fix --",
-    "*.{js,jsx,ts,tsx,mjs,cjs}": "turbo run lint -- --fix"
+    "packages/docusaurus-plugin-tailwind/**/*.{js,jsx,ts,tsx}": [
+      "cd packages/docusaurus-plugin-tailwind && eslint --ext .js,.jsx,.ts,.tsx --fix ."
+    ],
+    "packages/ui/**/*.{js,jsx,ts,tsx}": [
+      "cd packages/ui && eslint --ext .js,.jsx,.ts,.tsx --fix ."
+    ],
+    "apps/website/**/*.{js,jsx,ts,tsx}": [
+      "eslint --ext .js,.jsx,.ts,.tsx --fix ."
+    ]
   },
   "packageManager": "pnpm@9.4.0"
 }

--- a/packages/docusaurus-plugin-tailwind/.eslintrc.js
+++ b/packages/docusaurus-plugin-tailwind/.eslintrc.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Janus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  parserOptions: {
+    project: './tsconfig.json',
+  },
+};


### PR DESCRIPTION
## What does this PR do / why we need it

Existing `lint-staged` has issues due to the directory in which it is running, which can result in the following error locally:

```console
docusaurus-plugin-tailwind:lint: 
docusaurus-plugin-tailwind:lint: > docusaurus-plugin-tailwind@0.0.0 lint /Users/bgriggs/backstage/janus-idp.github.io/packages/docusaurus-plugin-tailwind
docusaurus-plugin-tailwind:lint: > eslint . --ext .js,.jsx,.ts,.tsx "--fix" "/Users/bgriggs/backstage/janus-idp.github.io/packages/ui/components/banner/banner.tsx"
docusaurus-plugin-tailwind:lint: 
docusaurus-plugin-tailwind:lint: Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.
docusaurus-plugin-tailwind:lint: 
docusaurus-plugin-tailwind:lint: /Users/bgriggs/backstage/janus-idp.github.io/packages/ui/components/banner/banner.tsx
docusaurus-plugin-tailwind:lint:   0:0  error  Parsing error: ESLint was configured to run on `/Users/bgriggs/backstage/janus-idp.github.io/packages/ui/components/banner/banner.tsx` using `parserOptions.project`: /users/bgriggs/backstage/janus-idp.github.io/packages/docusaurus-plugin-tailwind/tsconfig.json
docusaurus-plugin-tailwind:lint: However, that TSConfig does not include this file. Either:
docusaurus-plugin-tailwind:lint: - Change ESLint's list of included files to not include this file
docusaurus-plugin-tailwind:lint: - Change that TSConfig to include this file
docusaurus-plugin-tailwind:lint: - Create a new TSConfig that includes this file and include it in your parserOptions.project
docusaurus-plugin-tailwind:lint: See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
docusaurus-plugin-tailwind:lint: 
docusaurus-plugin-tailwind:lint: ✖ 1 problem (1 error, 0 warnings)
docusaurus-plugin-tailwind:lint: 
docusaurus-plugin-tailwind:lint:  ELIFECYCLE  Command failed with exit code 1.
```

Note that it's trying to lint `packages/ui/components/banner/banner.tsx` from within the `docusaurus-plugin-tailwind` directory. This PR fixes this by adding explicit steps to run the `eslint` command from the appropriate directories.