### PR TITLE
removed Documentation section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ Go to the `apps/website` folder
 
 To add or update a blog, you need to go to the `blog` sub folder. The blog must be in Markdown format (MDX).
 
-### Documentation
-
-To add or update documentation, you need to go to the `docs` sub folder. The documentation must be in Markdown format (MD).
-
 ### Plugins
 
 To add or update a plugin, you need to edit the `content/plugin-list.ts` file. The content of the plugin page is coming from the README of the plugin itself in the [plugin repo](https://github.com/janus-idp/backstage-plugins/tree/main/plugins).


### PR DESCRIPTION
## What does this PR do / why we need it
Removed the Documentation section from `README.md` as we don't have a `docs` subfolder anymore.
## Which issue(s) does this PR fix

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
