### PR TITLE
chore: fix dirty workspace following bump to Husky v9.1.1

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 ./.husky/scripts/sync-node-modules

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 ./.husky/scripts/sync-node-modules

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 ./.husky/scripts/sync-node-modules

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 npm run lint-staged


### PR DESCRIPTION
## What does this PR do / why we need it

PR checks in the janus-idp/backstage-plugins repo are failing due to an error
about dirty workspaces. See [1].

This has been narrowed down to the bump of Husky to v9.1.1 [2],
which, according to the release notes [3], makes Husky automatically
remove some deprecated statements.

(That being said, not sure why we are building this repo from PRs in the
backstage-plugins repo)

[1] https://github.com/janus-idp/backstage-plugins/actions/workflows/pr-website.yaml
[2] https://github.com/janus-idp/janus-idp.github.io/pull/330
[3] https://github.com/typicode/husky/releases/tag/v9.1.1

## Which issue(s) does this PR fix

Lots of PR failures since yesterday - see https://github.com/janus-idp/backstage-plugins/actions/workflows/pr-website.yaml

## PR acceptance criteria

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
